### PR TITLE
👌 IMPROVE: Set the default endpoint name to the function name

### DIFF
--- a/ninja/router.py
+++ b/ninja/router.py
@@ -281,6 +281,10 @@ class Router:
             self.path_operations[path] = path_view
         else:
             path_view = self.path_operations[path]
+        
+        if not url_name:
+            url_name = view_func.__name__
+
         path_view.add_operation(
             path=path,
             methods=methods,


### PR DESCRIPTION
This will set the default endpoint name according to the view function name, if the value of the `url_name` parameter is not set.